### PR TITLE
Update repair_building.nut

### DIFF
--- a/scripts/entity/world/camp/buildings/repair_building.nut
+++ b/scripts/entity/world/camp/buildings/repair_building.nut
@@ -386,7 +386,7 @@ this.repair_building <- this.inherit("scripts/entity/world/camp/camp_building", 
 			{
 				local consumed = needed * modifiers.Consumption;
 				this.m.ToolsUsed += consumed * perkMod;
-				this.World.Assets.addArmorPartsF(consumed * -1.0);
+				this.World.Assets.addArmorPartsF(consumed * perkMod * -1.0);
 			}
 
 			if (r.Item.getRepair() >= r.Item.getRepairMax())


### PR DESCRIPTION
Fixed repair while camping to reduce tool usage when brothers have the spare tools and tool drawer perks, matching the tool usage tooltip.
